### PR TITLE
Fix test at `test_geometry_serializer_method_field_nogeo`

### DIFF
--- a/rest_framework_gis/serializers.py
+++ b/rest_framework_gis/serializers.py
@@ -96,7 +96,9 @@ class GeoFeatureModelSerializer(ModelSerializer):
                     meta.fields += additional_fields
 
         check_excludes(meta.geo_field, 'geo_field')
-        add_to_fields(meta.geo_field)
+
+        if meta.geo_field is not None:
+            add_to_fields(meta.geo_field)
 
         meta.bbox_geo_field = getattr(meta, 'bbox_geo_field', None)
         if meta.bbox_geo_field:


### PR DESCRIPTION
The function `add_to_fields` does not have any checks for `None` and
since the app now supports `geo_field = None` it adds it to the fields
of the serializer. In any case, adding an `assert` in the `add_to_fields`
function would have made the error obvious in the first place.